### PR TITLE
Adds notebook for pEW vs Phase

### DIFF
--- a/notebooks/pew_phase_evolution.ipynb
+++ b/notebooks/pew_phase_evolution.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PeW Evolution with Phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sndata.csp import DR1, DR3\n",
+    "from sndata.utils import convert_to_jd\n",
+    "\n",
+    "results_dir = Path('.').resolve().parent / 'results'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading in data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dr3 = DR3()\n",
+    "dr3.download_module_data()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@np.vectorize\n",
+    "def get_csp_t0(obj_id):\n",
+    "    \"\"\"Get the t0 value for CSP targets\n",
+    "\n",
+    "    Args:\n",
+    "        obj_id (str): The object identifier\n",
+    "\n",
+    "    Returns:\n",
+    "        The time of B-band maximum in units of\n",
+    "    \"\"\"\n",
+    "\n",
+    "    csp_table_3 = dr3.load_table(3).to_pandas(index='SN')\n",
+    "    \n",
+    "    # Unknown object ID\n",
+    "    if obj_id not in csp_table_3.index:\n",
+    "        return np.nan\n",
+    "\n",
+    "    t0_mjd = csp_table_3.loc[obj_id]['T(Bmax)']\n",
+    "\n",
+    "    # Known object Id with unknown peak time\n",
+    "    if np.isnan(t0_mjd):\n",
+    "        return np.nan\n",
+    "\n",
+    "    return convert_to_jd(t0_mjd)\n",
+    "\n",
+    "\n",
+    "def calc_branch_class(pw6, pw7):\n",
+    "    \"\"\"Calculate the branch classification for given pEW\n",
+    "    \n",
+    "    Args:\n",
+    "        pw6 (ndarray): Array of EW measurements for feature 6\n",
+    "        pw7 (ndarray): Array of EW measurements for feature 7\n",
+    "        \n",
+    "    Returns:\n",
+    "        An array of strings\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    branch_types = np.full_like(pw6, 'CN', dtype='U10')\n",
+    "    branch_types[pw6 > 30] = 'CL' \n",
+    "    branch_types[(pw6 < 30) & (pw7 > 105)] = 'BL' \n",
+    "    branch_types[pw7 < 70] = 'SS'  \n",
+    "    return pd.Series(branch_types, index=pw6.index, name='class')\n",
+    "\n",
+    "\n",
+    "def read_in_pipeline_result(path):\n",
+    "    \"\"\"Read pEW values from analysis pipline file\n",
+    "    \n",
+    "    Adds columns for Branch classifications determined by the\n",
+    "    measured pEW values and spectral subtypes determined from \n",
+    "    CSP DR1.\n",
+    "    \n",
+    "    Args:\n",
+    "        path (str): Path of the file to read\n",
+    "        \n",
+    "    Returns:\n",
+    "        A pandas Dataframe indexed by feat_name and obj_id\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    df = pd.read_csv(path, index_col=['feat_name', 'obj_id'])\n",
+    "\n",
+    "    # Add phases using CSP DR3 t0 values\n",
+    "    obj_id = df.index.get_level_values(1)\n",
+    "    df['phase'] = get_csp_t0(obj_id) - df.time\n",
+    "\n",
+    "    # Add Branch style classifications\n",
+    "    pw = pd.DataFrame({\n",
+    "        'pW6': df.loc['pW6'].pew, \n",
+    "        'pW7': df.loc['pW7'].pew}\n",
+    "    ).dropna()\n",
+    "    df = df.join(calc_branch_class(pw.pW6, pw.pW7), on='obj_id')\n",
+    "    \n",
+    "    # Add spectral subtypes\n",
+    "    csp_table_2 = dr3.load_table(2)\n",
+    "    subtypes = pd.DataFrame({'spec_type': csp_table_2['Subtype1']}, index=csp_table_2['SN'])\n",
+    "    df = df.join(subtypes, on='obj_id')\n",
+    "    \n",
+    "    return df\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ella = read_in_pipeline_result(results_dir / 'ella_csp.csv')\n",
+    "emily = read_in_pipeline_result(results_dir / 'emily_csp.csv')\n",
+    "anish = read_in_pipeline_result(results_dir / 'anish_csp.csv')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pew Vs. Phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "def plot_feat_evolution(df, feat_name, color_by='class', axis=None):\n",
+    "    \"\"\"Plot the strength of a feature vs phase\n",
+    "    \n",
+    "    Args:\n",
+    "        df  (DataFrame): Dataframe to plot data from\n",
+    "        feat_name (str): Name of the feature (index) to plot\n",
+    "        color_by  (str): Name of the column to color code points by\n",
+    "        axis     (Axis): Optionally plot on a given axis\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    if axis is None:\n",
+    "        fig, axis = plt.subplots(figsize=(6, 4))\n",
+    "\n",
+    "    feature_data = df.loc[feat_name]\n",
+    "    for class_name, class_data in feature_data.groupby(color_by):\n",
+    "        x = class_data.phase\n",
+    "        y = class_data.pew\n",
+    "        y_err = class_data.pew_samperr\n",
+    "\n",
+    "        axis.errorbar(x, y, yerr=y_err, linestyle='')\n",
+    "        axis.scatter(x, y, s=15, label=class_name)\n",
+    "    \n",
+    "    axis.legend()\n",
+    "    axis.set_title(feat_name)\n",
+    "    if axis is None:\n",
+    "        axis.set_xlabel('Phase', fontsize=12)\n",
+    "        axis.set_ylabel(r'pEW ($\\AA$)', fontsize=12)\n",
+    "        \n",
+    "    axis.set_xlim(-15, 15)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_using = anish\n",
+    "plot_features = [f'pW{i}' for i in range(1, 9)]\n",
+    "\n",
+    "for feature in plot_features:\n",
+    "    fig, axes = plt.subplots(1, 2, sharey=True)\n",
+    "    for axis, color_by in zip(axes, ('class', 'spec_type')):\n",
+    "        plot_feat_evolution(plot_using, feature, color_by, axis=axis)\n",
+    "        axis.set_xlabel('Phase', fontsize=12)\n",
+    "\n",
+    "    axes[0].set_ylabel('pEW', fontsize=12)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:SN-Spectral-Evolution] *",
+   "language": "python",
+   "name": "conda-env-SN-Spectral-Evolution-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/pew_phase_evolution.ipynb
+++ b/notebooks/pew_phase_evolution.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,13 +167,14 @@
     "        fig, axis = plt.subplots(figsize=(6, 4))\n",
     "\n",
     "    feature_data = df.loc[feat_name]\n",
-    "    for class_name, class_data in feature_data.groupby(color_by):\n",
+    "    for i, (class_name, class_data) in enumerate(feature_data.groupby(color_by)):\n",
+    "        class_data = class_data.sort_values('phase')\n",
     "        x = class_data.phase\n",
     "        y = class_data.pew\n",
     "        y_err = class_data.pew_samperr\n",
     "\n",
-    "        axis.errorbar(x, y, yerr=y_err, linestyle='')\n",
-    "        axis.scatter(x, y, s=15, label=class_name)\n",
+    "        axis.errorbar(x, y, yerr=y_err, linestyle='', color=f'C{i}')\n",
+    "        axis.scatter(x, y, s=15, label=class_name, color=f'C{i}')\n",
     "    \n",
     "    axis.legend()\n",
     "    axis.set_title(feat_name)\n",


### PR DESCRIPTION
This PR adds a short notebook that plots pEW measurements as a function of phase. This is similar to the plots from Bronder et al., except I have added color coding for both spectral and Branch subtypes. I have also not included the template pEW or 1-sigma shaded region.